### PR TITLE
アクセスされたserver_nameに応じて、ServerInfoを切り替える

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -40,7 +40,7 @@ int Server::Run( void ) {
             this->listenSocket(sock);
             this->registerDescriptor(sock, POLLIN);
             this->addListeningDescriptor(sock);
-            sd_listen_map_[sock] = listen_addr;
+            listen_sd_to_addr_[sock] = listen_addr;
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             return 1;
@@ -191,7 +191,7 @@ HttpResponse Server::getCachedResponse( int client_sd ) {
 bool Server::isListenedAddress( const std::pair<std::string, int>& addr ) {
     std::map< int, std::pair<std::string, int> >::iterator it;
 
-    for (it = sd_listen_map_.begin(); it != sd_listen_map_.end(); ++it) {        
+    for (it = listen_sd_to_addr_.begin(); it != listen_sd_to_addr_.end(); ++it) {        
         std::pair<std::string, int> listened_addr = (*it).second;
         if (addr == listened_addr) {
             return true;
@@ -199,4 +199,16 @@ bool Server::isListenedAddress( const std::pair<std::string, int>& addr ) {
     }
 
     return false;
+}
+
+const std::pair<std::string, int>& Server::getListenSdToAddr( int sd ) {
+    return listen_sd_to_addr_[sd];
+};
+
+const std::pair<std::string, int>& Server::getClientSdToAddr( int sd ) {
+    return client_sd_to_addr_[sd];
+};
+
+void Server::setClientSdToAddr( int sd, std::pair<std::string, int> addr ) {
+    client_sd_to_addr_[sd] = addr;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -211,6 +211,6 @@ void Server::setClientSdToAddr( int sd, std::pair<std::string, int> addr ) {
     client_sd_to_addr_[sd] = addr;
 }
 
-void Server::deleteClientSdToAddr( int sd ) {
+void Server::removeClientSdToAddr( int sd ) {
     client_sd_to_addr_.erase(sd);
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -76,6 +76,8 @@ void Server::bindSocket( int sock, const ServerInfo& info ) const {
     if (bind(sock, (struct sockaddr*)&addr, addr_size) < 0) {
         SYSCALL_ERROR("bind");
     }
+
+    sd_addr_map_[sock] = std::pair<std::string, int>(info.listen.addr, info.listen.port);
 }
 
 void Server::listenSocket( int sock ) const {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -26,13 +26,13 @@ int Server::Run( void ) {
     std::vector<ServerInfo> servers_info = this->conf_.getServersInfo();
 
     for (size_t i = 0; i < servers_info.size(); ++i) {
-        std::pair<std::string, int> addr = \
+        std::pair<std::string, int> listen_addr = \
             std::pair<std::string, int>(servers_info[i].listen.addr, servers_info[i].listen.port);
         
-        if (listen_addr_set_.count(addr)) {
+        if (listen_addr_set_.count(listen_addr)) {
             continue;
         }
-        listen_addr_set_.insert(addr);
+        listen_addr_set_.insert(listen_addr);
 
         try {
             int sock = createSocket();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -212,3 +212,7 @@ const std::pair<std::string, int>& Server::getClientSdToAddr( int sd ) {
 void Server::setClientSdToAddr( int sd, std::pair<std::string, int> addr ) {
     client_sd_to_addr_[sd] = addr;
 }
+
+void Server::deleteClientSdToAddr( int sd ) {
+    client_sd_to_addr_.erase(sd);
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -41,6 +41,7 @@ int Server::Run( void ) {
             this->listenSocket(sock);
             this->registerDescriptor(sock, POLLIN);
             this->addListeningDescriptor(sock);
+            sd_listen_map_[sock] = listen_addr;
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             return 1;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -28,11 +28,10 @@ int Server::Run( void ) {
     for (size_t i = 0; i < servers_info.size(); ++i) {
         std::pair<std::string, int> listen_addr = \
             std::pair<std::string, int>(servers_info[i].listen.addr, servers_info[i].listen.port);
-        
-        if (listen_addr_set_.count(listen_addr)) {
+
+        if (this->isListenedAddress(listen_addr)) {
             continue;
         }
-        listen_addr_set_.insert(listen_addr);
 
         try {
             int sock = createSocket();
@@ -187,4 +186,17 @@ void Server::removeCachedResponse( int client_sd ) {
 
 HttpResponse Server::getCachedResponse( int client_sd ) {
     return resp_cache_[client_sd];
+}
+
+bool Server::isListenedAddress( const std::pair<std::string, int>& addr ) {
+    std::map< int, std::pair<std::string, int> >::iterator it;
+
+    for (it = sd_listen_map_.begin(); it != sd_listen_map_.end(); ++it) {        
+        std::pair<std::string, int> listened_addr = (*it).second;
+        if (addr == listened_addr) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -24,7 +24,16 @@ int Server::Init( const std::string& conf_file ) {
 
 int Server::Run( void ) {
     std::vector<ServerInfo> servers_info = this->conf_.getServersInfo();
+
     for (size_t i = 0; i < servers_info.size(); ++i) {
+        std::pair<std::string, int> addr = \
+            std::pair<std::string, int>(servers_info[i].listen.addr, servers_info[i].listen.port);
+        
+        if (listen_addr_set_.count(addr)) {
+            continue;
+        }
+        listen_addr_set_.insert(addr);
+
         try {
             int sock = createSocket();
             fcntl(sock, F_SETFL, O_NONBLOCK);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -76,8 +76,6 @@ void Server::bindSocket( int sock, const ServerInfo& info ) const {
     if (bind(sock, (struct sockaddr*)&addr, addr_size) < 0) {
         SYSCALL_ERROR("bind");
     }
-
-    sd_addr_map_[sock] = std::pair<std::string, int>(info.listen.addr, info.listen.port);
 }
 
 void Server::listenSocket( int sock ) const {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,8 +1,7 @@
 #include "Server.hpp"
 
 Server::Server( void )
-: listening_fds_(std::set<int>()),
-resp_cache_(std::map<int, HttpResponse>()),
+: resp_cache_(std::map<int, HttpResponse>()),
 nfds_(0), conf_(Config())
 {
     memset(fds_, 0, sizeof(fds_));
@@ -39,8 +38,7 @@ int Server::Run( void ) {
             this->bindSocket(sock, servers_info[i]);
             this->listenSocket(sock);
             this->registerDescriptor(sock, POLLIN);
-            this->addListeningDescriptor(sock);
-            listen_sd_to_addr_[sock] = listen_addr;
+            this->setListenSdToAddr(sock, listen_addr);
         } catch (std::exception &e) {
             std::cerr << e.what() << std::endl;
             return 1;
@@ -168,12 +166,8 @@ std::vector<Event*> Server::getRaisedEvents( void ) {
     return events;
 }
 
-void Server::addListeningDescriptor( int sock ) {
-    listening_fds_.insert(sock);
-}
-
 bool Server::isListeningDescriptor( int sock ) const {
-    return (listening_fds_.count(sock) > 0);
+    return (listen_sd_to_addr_.count(sock) > 0);
 }
 
 void Server::cacheResponse( int client_sd, const HttpResponse& resp ) {
@@ -208,6 +202,10 @@ const std::pair<std::string, int>& Server::getListenSdToAddr( int sd ) {
 const std::pair<std::string, int>& Server::getClientSdToAddr( int sd ) {
     return client_sd_to_addr_[sd];
 };
+
+void Server::setListenSdToAddr( int sd, std::pair<std::string, int> addr ) {
+    listen_sd_to_addr_[sd] = addr;
+}
 
 void Server::setClientSdToAddr( int sd, std::pair<std::string, int> addr ) {
     client_sd_to_addr_[sd] = addr;

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -55,9 +55,9 @@ class Server {
 
         Config getConf( void ) const { return conf_; }
 
-        std::map< int, std::pair<std::string, int> >& getSdListenMap() {
-            return sd_listen_map_;
-        };
+        const std::pair<std::string, int>& getListenSdToAddr( int sd );
+        const std::pair<std::string, int>& getClientSdToAddr( int sd );
+        void setClientSdToAddr( int sd, std::pair<std::string, int> addr );
 
         const static size_t MAX_POLL_FDS = 200;
         const static int BACKLOG = 1024;
@@ -70,7 +70,8 @@ class Server {
         nfds_t nfds_;
         Config conf_;
 
-        std::map< int, std::pair<std::string, int> > sd_listen_map_;
+        std::map< int, std::pair<std::string, int> > client_sd_to_addr_;
+        std::map< int, std::pair<std::string, int> > listen_sd_to_addr_;
 };
 
 #endif

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -64,7 +64,6 @@ class Server {
         struct pollfd fds_[MAX_POLL_FDS];
         nfds_t nfds_;
         Config conf_;
-        std::map< int, std::pair<std::string, int> > sd_addr_map_;
 };
 
 #endif

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -51,6 +51,7 @@ class Server {
         void cacheResponse( int client_sd, const HttpResponse& resp );
         HttpResponse getCachedResponse( int client_sd );
         void removeCachedResponse( int client_sd );
+        bool isListenedAddress( const std::pair<std::string, int>& addr );
 
         Config getConf( void ) const { return conf_; }
 
@@ -69,7 +70,6 @@ class Server {
         nfds_t nfds_;
         Config conf_;
 
-        std::set< std::pair<std::string, int> > listen_addr_set_;
         std::map< int, std::pair<std::string, int> > sd_listen_map_;
 };
 

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -64,6 +64,7 @@ class Server {
         struct pollfd fds_[MAX_POLL_FDS];
         nfds_t nfds_;
         Config conf_;
+        std::map< int, std::pair<std::string, int> > sd_addr_map_;
 };
 
 #endif

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -58,7 +58,7 @@ class Server {
         const std::pair<std::string, int>& getClientSdToAddr( int sd );
         void setListenSdToAddr( int sd, std::pair<std::string, int> addr );
         void setClientSdToAddr( int sd, std::pair<std::string, int> addr );
-        void deleteClientSdToAddr( int sd );
+        void removeClientSdToAddr( int sd );
 
         const static size_t MAX_POLL_FDS = 200;
         const static int BACKLOG = 1024;

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -54,6 +54,10 @@ class Server {
 
         Config getConf( void ) const { return conf_; }
 
+        std::map< int, std::pair<std::string, int> >& getSdListenMap() {
+            return sd_listen_map_;
+        };
+
         const static size_t MAX_POLL_FDS = 200;
         const static int BACKLOG = 1024;
         const static int TIMEOUT = -1; // infinity
@@ -66,6 +70,7 @@ class Server {
         Config conf_;
 
         std::set< std::pair<std::string, int> > listen_addr_set_;
+        std::map< int, std::pair<std::string, int> > sd_listen_map_;
 };
 
 #endif

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -58,6 +58,7 @@ class Server {
         const std::pair<std::string, int>& getListenSdToAddr( int sd );
         const std::pair<std::string, int>& getClientSdToAddr( int sd );
         void setClientSdToAddr( int sd, std::pair<std::string, int> addr );
+        void deleteClientSdToAddr( int sd );
 
         const static size_t MAX_POLL_FDS = 200;
         const static int BACKLOG = 1024;

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -45,7 +45,6 @@ class Server {
         std::vector<Event*> waitForEvents( void );
         std::vector<Event*> getRaisedEvents( void );
 
-        void addListeningDescriptor( int sock );
         bool isListeningDescriptor( int sock ) const;
 
         void cacheResponse( int client_sd, const HttpResponse& resp );
@@ -57,6 +56,7 @@ class Server {
 
         const std::pair<std::string, int>& getListenSdToAddr( int sd );
         const std::pair<std::string, int>& getClientSdToAddr( int sd );
+        void setListenSdToAddr( int sd, std::pair<std::string, int> addr );
         void setClientSdToAddr( int sd, std::pair<std::string, int> addr );
         void deleteClientSdToAddr( int sd );
 
@@ -65,7 +65,6 @@ class Server {
         const static int TIMEOUT = -1; // infinity
 
     private:
-        std::set<int> listening_fds_;
         std::map<int, HttpResponse> resp_cache_;
         struct pollfd fds_[MAX_POLL_FDS];
         nfds_t nfds_;

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -64,6 +64,8 @@ class Server {
         struct pollfd fds_[MAX_POLL_FDS];
         nfds_t nfds_;
         Config conf_;
+
+        std::set< std::pair<std::string, int> > listen_addr_set_;
 };
 
 #endif

--- a/src/events/NewConnectionEvent.cpp
+++ b/src/events/NewConnectionEvent.cpp
@@ -23,7 +23,7 @@ int NewConnectionEvent::handler( void ) {
         }
 
         server_.registerDescriptor(new_sd, POLLIN | POLLOUT);
-        server_.getSdListenMap()[new_sd] = server_.getSdListenMap()[listen_sd_];
+        server_.setClientSdToAddr(new_sd, server_.getListenSdToAddr(listen_sd_));
     }
 
     return (0);

--- a/src/events/NewConnectionEvent.cpp
+++ b/src/events/NewConnectionEvent.cpp
@@ -23,6 +23,7 @@ int NewConnectionEvent::handler( void ) {
         }
 
         server_.registerDescriptor(new_sd, POLLIN | POLLOUT);
+        server_.getSdListenMap()[new_sd] = server_.getSdListenMap()[listen_sd_];
     }
 
     return (0);

--- a/src/events/RecieveRequestEvent.cpp
+++ b/src/events/RecieveRequestEvent.cpp
@@ -49,7 +49,7 @@ int RecieveRequestEvent::handler( void ) {
 
     // もしrequestをcacheする場合、以下はSendResponseEvent->hander内に記述
     // host matching
-    std::pair< std::string, int > listen_addr = server_.getSdListenMap()[client_sd_];
+    std::pair< std::string, int > listen_addr = server_.getClientSdToAddr(client_sd_);
     if (req.hostMatching(server_.getConf().getServersInfo(), listen_addr)) {
         server_.cacheResponse(
             client_sd_,

--- a/src/events/RecieveRequestEvent.cpp
+++ b/src/events/RecieveRequestEvent.cpp
@@ -49,7 +49,8 @@ int RecieveRequestEvent::handler( void ) {
 
     // もしrequestをcacheする場合、以下はSendResponseEvent->hander内に記述
     // host matching
-    if (req.hostMatching(server_.getConf().getServersInfo())) {
+    std::pair< std::string, int > listen_addr = server_.getSdListenMap()[client_sd_];
+    if (req.hostMatching(server_.getConf().getServersInfo(), listen_addr)) {
         server_.cacheResponse(
             client_sd_,
             HttpResponse::createErrorResponse(

--- a/src/events/SendResponseEvent.cpp
+++ b/src/events/SendResponseEvent.cpp
@@ -16,7 +16,7 @@ int SendResponseEvent::handler( void ) {
         perror("close");
     }
 
-    server_.deleteClientSdToAddr(client_sd_);
+    server_.removeClientSdToAddr(client_sd_);
     client_sd_ = CLOSED_FD;
 
     return (0);

--- a/src/events/SendResponseEvent.cpp
+++ b/src/events/SendResponseEvent.cpp
@@ -15,6 +15,8 @@ int SendResponseEvent::handler( void ) {
     if (close(client_sd_) < 0) {
         perror("close");
     }
+
+    server_.deleteClientSdToAddr(client_sd_);
     client_sd_ = CLOSED_FD;
 
     return (0);

--- a/src/io/ChunkParser.hpp
+++ b/src/io/ChunkParser.hpp
@@ -9,7 +9,7 @@
 
 class ChunkParser {
     public:
-        typedef typename std::vector<std::string>::const_iterator iterator;
+        typedef std::vector<std::string>::const_iterator iterator;
         
         static const ssize_t MAX_CHUNK_SIZE = 0xffff;
         static std::string parse( const std::string& chunked );

--- a/src/io/HttpRequest.cpp
+++ b/src/io/HttpRequest.cpp
@@ -137,6 +137,19 @@ int HttpRequest::hostMatching( const std::vector<ServerInfo>& servers_info ) {
     const std::string hostname = this->getHostName();
     const std::string hostname_resolved = this->getHostName(true);
 
+    // server_name Matching
+    for (size_t i = 0; i < servers_info.size(); ++i) {
+        ServerInfo info = servers_info[i];
+        const std::string listen_str =
+            info.listen.addr + ":" + sizeToString(info.listen.port);
+
+        if ((hostname == listen_str) || (hostname_resolved == listen_str)) {
+            host_info_ = info;
+            return 0;
+        }
+    }
+
+    // default Matching
     for (size_t i = 0; i < servers_info.size(); ++i) {
         ServerInfo info = servers_info[i];
         const std::string listen_str =

--- a/src/io/HttpRequest.cpp
+++ b/src/io/HttpRequest.cpp
@@ -137,19 +137,6 @@ int HttpRequest::hostMatching( const std::vector<ServerInfo>& servers_info ) {
     const std::string hostname = this->getHostName();
     const std::string hostname_resolved = this->getHostName(true);
 
-    // server_name Matching
-    for (size_t i = 0; i < servers_info.size(); ++i) {
-        ServerInfo info = servers_info[i];
-        const std::string listen_str =
-            info.listen.addr + ":" + sizeToString(info.listen.port);
-
-        if ((hostname == listen_str) || (hostname_resolved == listen_str)) {
-            host_info_ = info;
-            return 0;
-        }
-    }
-
-    // default Matching
     for (size_t i = 0; i < servers_info.size(); ++i) {
         ServerInfo info = servers_info[i];
         const std::string listen_str =

--- a/src/io/HttpRequest.hpp
+++ b/src/io/HttpRequest.hpp
@@ -35,7 +35,10 @@ class HttpRequest {
         bool isChunked( void ) const;
         int unchunk( void );
         int parse( const std::string& request );
-        int hostMatching( const std::vector<ServerInfo>& servers_info );
+        int hostMatching(
+            const std::vector<ServerInfo>& servers_info,
+            std::pair< std::string, int > listen_addr
+            );
         int locationMatching( void );
         void printRequest( void ) const;
 


### PR DESCRIPTION
Issue: #20 

下記のケースで動作しました。
conf
```conf
server {
    listen 127.0.0.1:4242;
    server_name hoge.com;
    location / {
        root ./tmp/hoge/;
        allow_methods GET POST DELETE;
    }
}

server {
    listen 127.0.0.1:4242;
    server_name fuga.com;
    location / {
        root ./tmp/fuga/;
        allow_methods GET POST DELETE;
    }
}

server {
    listen 127.0.0.1:4242;
    server_name piyo.com;
    location / {
        root ./tmp/piyo/;
        allow_methods GET POST DELETE;
    }
}

server {
    listen 127.0.0.1:4243;
    server_name hoge.com;
    location / {
        root ./tmp/hoge1/;
        allow_methods GET POST DELETE;
    }
}

server {
    listen 127.0.0.1:4243;
    server_name foo.com;
    location / {
        root ./tmp/foo/;
        allow_methods GET POST DELETE;
    }
}
```

テスト結果
```
curl -v "localhost:4242/index.html"
-> hoge/index.html

curl -v -H "Host:hoge.com" "localhost:4242/index.html"
-> hoge/index.html

curl -v -H "Host:fuga.com" "localhost:4242/index.html"
-> fuga/index.html

curl -v -H "Host:piyo.com" "localhost:4242/index.html"
-> piyo/index.html

curl -v -H "Host:foo.com" "localhost:4242/index.html"
-> hoge/index.html

curl -v "localhost:4243/index.html"
-> hoge1/index.html

curl -v -H "Host:hoge.com" "localhost:4243/index.html"
-> hoge1/index.html

curl -v -H "Host:fuga.com" "localhost:4243/index.html"
-> hoge1/index.html

curl -v -H "Host:piyo.com" "localhost:4243/index.html"
-> hoge1/index.html

curl -v -H "Host:foo.com" "localhost:4243/index.html"
-> foo/index.html
```